### PR TITLE
fix: icon Size on foodPage

### DIFF
--- a/lib/home/food_page_body.dart
+++ b/lib/home/food_page_body.dart
@@ -143,18 +143,21 @@ class _FoodPageBodyState extends State<FoodPageBody> {
                                 IconAndTextWidget(
                                   icon: Icons.circle_sharp,
                                   text: "Normal",
+                                  iconSize: Dimensions.textIconSize12,
                                   iconColor: AppColors.iconColor1,
                                 ),
                                 const SizedBox(width: 10),
                                 IconAndTextWidget(
                                   icon: Icons.location_on,
                                   text: "1.7km",
+                                  iconSize: Dimensions.textIconSize12,
                                   iconColor: AppColors.mainColor,
                                 ),
                                 const SizedBox(width: 10),
                                 IconAndTextWidget(
                                   icon: Icons.access_time_rounded,
                                   text: "32min",
+                                  iconSize: Dimensions.textIconSize12,
                                   iconColor: AppColors.iconColor2,
                                 )
                               ],
@@ -284,18 +287,21 @@ class _FoodPageBodyState extends State<FoodPageBody> {
                         IconAndTextWidget(
                           icon: Icons.circle_sharp,
                           text: "Normal",
+                          iconSize: Dimensions.iconSize24,
                           iconColor: AppColors.iconColor1,
                         ),
                         const SizedBox(width: 10),
                         IconAndTextWidget(
                           icon: Icons.location_on,
                           text: "1.7km",
+                          iconSize: Dimensions.iconSize24,
                           iconColor: AppColors.mainColor,
                         ),
                         const SizedBox(width: 10),
                         IconAndTextWidget(
                           icon: Icons.access_time_rounded,
                           text: "32min",
+                          iconSize: Dimensions.iconSize24,
                           iconColor: AppColors.iconColor2,
                         )
                       ],

--- a/lib/widgets/icon_and_text_widget.dart
+++ b/lib/widgets/icon_and_text_widget.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
-import 'package:myecommerce/utils/dimensions.dart';
 import 'package:myecommerce/widgets/small_text.dart';
 
 class IconAndTextWidget extends StatelessWidget {
   final IconData icon;
   final String text;
   final Color iconColor;
+  final double iconSize;
 
-  const IconAndTextWidget(
-      {Key? key,
-      required this.icon,
-      required this.text,
-      required this.iconColor})
-      : super(key: key);
+  const IconAndTextWidget({
+    Key? key,
+    required this.icon,
+    required this.text,
+    required this.iconColor,
+    required this.iconSize,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +22,7 @@ class IconAndTextWidget extends StatelessWidget {
         Icon(
           icon,
           color: iconColor,
-          size: Dimensions.textIconSize12,
+          size: iconSize,
         ),
         const SizedBox(width: 5),
         SmallText(text: text)


### PR DESCRIPTION
## Fix: iconAndTextSize of Main foodPage (Dynamic iconSize)

### Before : 
![Screenshot 2022-08-26 192136](https://user-images.githubusercontent.com/76255199/186919059-7e40af69-e947-4450-814c-68fee957a7ab.png)


### After: 
![Screenshot 2022-08-26 191952](https://user-images.githubusercontent.com/76255199/186918691-4f6ad132-244c-4d5c-995f-0c222a8fc98e.png)